### PR TITLE
catch error thrown in cross-domain iframe

### DIFF
--- a/src/jquery.caret.coffee
+++ b/src/jquery.caret.coffee
@@ -249,7 +249,10 @@
     # http://stackoverflow.com/questions/16010204/get-reference-of-window-object-from-a-dom-element
     oDocument = this[0].ownerDocument
     oWindow = oDocument.defaultView || oDocument.parentWindow
-    oFrame = oWindow.frameElement
+    try
+      oFrame = oWindow.frameElement
+    catch error
+      # throws error in cross-domain iframes
     caret = if Utils.contentEditable(this) then new EditableCaret(this) else new InputCaret(this)
     if methods[method]
       methods[method].apply caret, Array::slice.call(arguments, 1)

--- a/src/jquery.caret.js
+++ b/src/jquery.caret.js
@@ -318,10 +318,14 @@
     oWindow = null;
     oFrame = null;
     $.fn.caret = function(method) {
-      var caret;
+      var caret, error;
       oDocument = this[0].ownerDocument;
       oWindow = oDocument.defaultView || oDocument.parentWindow;
-      oFrame = oWindow.frameElement;
+      try {
+        oFrame = oWindow.frameElement;
+      } catch (_error) {
+        error = _error;
+      }
       caret = Utils.contentEditable(this) ? new EditableCaret(this) : new InputCaret(this);
       if (methods[method]) {
         return methods[method].apply(caret, Array.prototype.slice.call(arguments, 1));


### PR DESCRIPTION
When `$().caret()` is called in an `<iframe>`, calling `oWindow.frameElement` causes an error:

> SecurityError: Failed to read the 'frame' property from 'Window': Blocked a frame with origin "http://another-work" from accessing a cross-origin frame.

In this PR the error is catched so that it falls back to the condition that `oFrame` is `null`.
