### PR TITLE
Update bower.json to depend on jquery not jQuery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "index.html"
   ],
   "dependencies": {
-    "jQuery": ">=1.7.0"
+    "jquery": ">=1.7.0"
   },
   "devDependencies": {
     "jasmine-jquery": "~1.5.8"


### PR DESCRIPTION
**See ichord/At.js#157** (just merged)

It appears Bower will happily resolve _both_ jQuery and jquery:
in projects that specify both Caret.js and other dependencies relying
on jQuery, Bower will attempt to install jQuery twice, possibly with
differing versions.

In the case of a case insensitive filesystem (Windows and Mac, by
default), the jQuery components directory will be overwritten/merged.
See: bower/bower#1150

https://www.openproject.org/work_packages/7310
