### PR TITLE
Using 'ZERO WIDTH JOINER' char instead of "|" for offset calculations

### DIFF
--- a/src/jquery.caret.coffee
+++ b/src/jquery.caret.coffee
@@ -90,7 +90,7 @@ class EditableCaret
       # so we can't use it in all cases.
       if !offset or offset?.height == 0
         clonedRange = range.cloneRange()
-        shadowCaret = $ oDocument.createTextNode "|"
+        shadowCaret = $ oDocument.createTextNode "\u200D"
         clonedRange.insertNode shadowCaret[0]
         clonedRange.selectNode shadowCaret[0]
         rect = clonedRange.getBoundingClientRect()

--- a/src/jquery.caret.js
+++ b/src/jquery.caret.js
@@ -140,7 +140,7 @@ EditableCaret = (function() {
       }
       if (!offset || (offset != null ? offset.height : void 0) === 0) {
         clonedRange = range.cloneRange();
-        shadowCaret = $(oDocument.createTextNode("|"));
+        shadowCaret = $(oDocument.createTextNode("\u200D"));
         clonedRange.insertNode(shadowCaret[0]);
         clonedRange.selectNode(shadowCaret[0]);
         rect = clonedRange.getBoundingClientRect();


### PR DESCRIPTION
I noticed that Caret.js doesnt work well with languages that display connected chars such as arabic/persian/malayalam etc..

The code uses the char "|" to check the offset of a certain location. you should use the ZWJ char:
https://en.wikipedia.org/wiki/Zero-width_joiner

The advantage of using the 'zero width joiner' char is that:
- it has zero width as oppose to "|"
- and mainly it doesn't break chars that connect... 

Example:
العربية
الع|ربية
notice that "|" break the word and it's offset is different than it suppose to be

It might also solve issues with offset of numbers chars on RTL languages.
12345
will appear on RTL with "|" char: 345|12

Note: I'm just suggesting that on the way... I didn't check the code (forked and edited directly on github) and I didn't change getPosition function since it uses span element that wraps the "|" char and having an element instead of a text node with the ZWJ might not work - and still separate connected chars. 

Please check and update - for people who use those languages (quite a lot) 